### PR TITLE
Work around gclient confusion

### DIFF
--- a/build_engine/build_and_upload.sh
+++ b/build_engine/build_and_upload.sh
@@ -13,8 +13,16 @@ SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 echo "Building engine at $ENGINE_ROOT and uploading to gs://download.shorebird.dev"
 
 # First update our checkouts to the correct versions.
+# gclient sync -r src/flutter@${ENGINE_HASH}
+# doesn't seem to work, it seems to get stuck trying to
+# rebase the engine repo. So we do it manually.
+# Similar to https://bugs.chromium.org/p/chromium/issues/detail?id=584742
+cd $ENGINE_ROOT/src/flutter
+git fetch
+git checkout $ENGINE_HASH
+
 cd $ENGINE_ROOT
-gclient sync --revision src/flutter@$ENGINE_HASH
+gclient sync
 
 
 cd $SCRIPT_DIR

--- a/build_engine/upload.sh
+++ b/build_engine/upload.sh
@@ -8,6 +8,12 @@ ENGINE_HASH=$2
 ENGINE_SRC=$ENGINE_ROOT/src
 ENGINE_OUT=$ENGINE_SRC/out
 
+MANIFEST_FILE=`mktemp`
+# Build the artifacts manifest:
+# This is a hack, assuming we have a _shorebird checkout next to the engine.
+cd $ENGINE_ROOT/../_shorebird
+./shorebird/packages/artifact_proxy/tool/generate_manifest.sh $ENGINE_HASH > $MANIFEST_FILE
+
 # FIXME: This should not be in shell, it's too complicated/repetative.
 # Only need the libflutter.so (and flutter.jar) artifacts
 # Artifact list: https://github.com/shorebirdtech/shorebird/pull/222/commits/a1fbbf7b93029b90ebd79c9ffeaafd3ee475cf20
@@ -83,3 +89,5 @@ curl -L $GH_RELEASE/patch-x86_64-unknown-linux-gnu.zip -o patch-x86_64-unknown-l
 gsutil cp patch-x86_64-apple-darwin.zip $SHOREBIRD_ROOT/patch-darwin-x64.zip
 gsutil cp patch-x86_64-pc-windows-msvc.zip $SHOREBIRD_ROOT/patch-windows-x64.zip
 gsutil cp patch-x86_64-unknown-linux-gnu.zip $SHOREBIRD_ROOT/patch-linux-x64.zip
+
+gsutil cp $MANIFEST_FILE $SHOREBIRD_ROOT/artifacts_manifest.yaml


### PR DESCRIPTION
I think gclient is confused by our engine setup (that we have stable_codepush as our "main", etc.) and treats our checkouts as though they have commits which need rebasing (even when the checkout is already at the revision in question).

Working around this for now by doing the checkout manually.