### PR TITLE
chore: bump patch version

### DIFF
--- a/build_engine/upload.sh
+++ b/build_engine/upload.sh
@@ -90,7 +90,7 @@ gsutil cp $ENGINE_OUT/host_release_arm64/patch.zip $SHOREBIRD_ROOT/patch-darwin-
 
 TMP_DIR=$(mktemp -d)
 
-PATCH_VERSION=0.0.0
+PATCH_VERSION=0.0.1
 GH_RELEASE=https://github.com/shorebirdtech/updater/releases/download/patch-v$PATCH_VERSION/
 cd $TMP_DIR
 curl -L $GH_RELEASE/patch-x86_64-apple-darwin.zip -o patch-x86_64-apple-darwin.zip


### PR DESCRIPTION
Part of https://github.com/shorebirdtech/updater/releases/tag/patch-v0.0.1 .

Doing this to trigger the build artifact workflow which contains the [Linux fix](https://github.com/shorebirdtech/updater/commit/d3ec0a3aaf73ea0f7bcd57c0733c60b4218223ff). The main reason for the release was the last commit and we need to bump the version and upload the new artifact for the fix to take effect.