### PR TITLE
fix: fetch tags before building

### DIFF
--- a/build_engine/build_and_upload.sh
+++ b/build_engine/build_and_upload.sh
@@ -12,6 +12,10 @@ SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 
 echo "Building engine at $ENGINE_ROOT and uploading to gs://download.shorebird.dev"
 
+cd $ENGINE_ROOT/src/third_party/dart
+git fetch
+git fetch --tags upstream
+
 # First update our checkouts to the correct versions.
 # gclient sync -r src/flutter@${ENGINE_HASH}
 # doesn't seem to work, it seems to get stuck trying to
@@ -19,6 +23,7 @@ echo "Building engine at $ENGINE_ROOT and uploading to gs://download.shorebird.d
 # Similar to https://bugs.chromium.org/p/chromium/issues/detail?id=584742
 cd $ENGINE_ROOT/src/flutter
 git fetch
+git fetch --tags upstream
 git checkout $ENGINE_HASH
 
 cd $ENGINE_ROOT


### PR DESCRIPTION
We think tags are used as part of the Dart/Flutter build process
to identify which version number it uses?  I'm not sure but
I think this helped fix "3.0.6 sources saying they're 3.0.5"