### PR TITLE
feat: Add build scripts for windows.

### DIFF
--- a/build_engine/update.sh
+++ b/build_engine/update.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+# Usage:
+# ./update.sh engine_path engine_hash
+
+# The path to the Flutter engine.
+ENGINE_ROOT=$1
+ENGINE_HASH=$2
+
+# Update Dart and the engine to make sure we have all the tags from upstream.
+# The version number in the builds seems to depend on these tags?
+cd $ENGINE_ROOT/src/third_party/dart
+git fetch
+git fetch --tags upstream
+
+# First update our checkouts to the correct versions.
+# gclient sync -r src/flutter@${ENGINE_HASH}
+# doesn't seem to work, it seems to get stuck trying to
+# rebase the engine repo. So we do it manually.
+# Similar to https://bugs.chromium.org/p/chromium/issues/detail?id=584742
+cd $ENGINE_ROOT/src/flutter
+git fetch
+git fetch --tags upstream
+git checkout $ENGINE_HASH
+
+cd $ENGINE_ROOT
+gclient sync

--- a/build_engine/win_build.sh
+++ b/build_engine/win_build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh -e
+
+# Usage:
+# ./win_build.sh engine_path
+
+ENGINE_ROOT=$1
+
+ENGINE_SRC=$ENGINE_ROOT/src
+ENGINE_OUT=$ENGINE_SRC/out
+
+# Compile the engine using the steps here:
+# https://github.com/flutter/flutter/wiki/Compiling-the-engine#compiling-for-android-from-macos-or-linux
+cd $ENGINE_SRC
+
+# Windows only needs gen_snapshot for each Android CPU type.
+# See https://github.com/flutter/engine/blob/e590b24f3962fda3ec9144dcee3f7565b195839a/ci/builders/windows_android_aot_engine.json
+
+
+# I haven't been able to get the right bits of VS2022 installed to build this.
+# Android arm64 release
+# ./flutter/tools/gn --android --android-cpu=arm64 --runtime-mode=release --no-goma
+# ninja -C ./out/android_release_arm64 gen_snapshot archive_win_gen_snapshot
+
+# Android arm32 release
+./flutter/tools/gn --runtime-mode=release --android --no-goma
+ninja -C out/android_release archive_win_gen_snapshot
+
+# Android x64 release
+./flutter/tools/gn --android --android-cpu=x64 --runtime-mode=release --no-goma
+ninja -C ./out/android_release_x64 archive_win_gen_snapshot
+
+# We could also build the `patch` tool for Windows here.

--- a/build_engine/win_build.sh
+++ b/build_engine/win_build.sh
@@ -18,6 +18,8 @@ cd $ENGINE_SRC
 
 # I haven't been able to get the right bits of VS2022 installed to build this.
 # Android arm64 release
+# FileNotFoundError: [Errno 2] No such file or directory:
+# 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.36.32532\\arm64\\Microsoft.VC142.CRT\\msvcp140.dll'
 # ./flutter/tools/gn --android --android-cpu=arm64 --runtime-mode=release --no-goma
 # ninja -C ./out/android_release_arm64 gen_snapshot archive_win_gen_snapshot
 

--- a/build_engine/win_build_and_upload.sh
+++ b/build_engine/win_build_and_upload.sh
@@ -1,7 +1,15 @@
 #!/bin/sh -e
 
 # Usage:
-# ./build_and_upload.sh engine_path engine_hash
+# ./win_build_and_upload.sh engine_path engine_hash
+
+# Example:
+# ./build_engine/build_engine/win_build_and_upload.sh \
+#  $HOME/Documents/GitHub/engine \
+# c906e2c58ff7cd8f57f5207c109559d1a9f1ce04
+
+# Currently written in shell for expediency, eventually should be
+# Dart or PowerShell.
 
 # The path to the Flutter engine.
 ENGINE_ROOT=$1
@@ -18,7 +26,7 @@ cd $SCRIPT_DIR
 ./update.sh $ENGINE_ROOT $ENGINE_HASH
 
 # Then run the build (this should just be a ninja call).
-./build.sh $ENGINE_ROOT
+./win_build.sh $ENGINE_ROOT
 
 # Copy Shorebird engine artifacts to Google Cloud Storage.
-./upload.sh $ENGINE_ROOT $ENGINE_HASH
+./win_upload.sh $ENGINE_ROOT $ENGINE_HASH

--- a/build_engine/win_upload.sh
+++ b/build_engine/win_upload.sh
@@ -22,8 +22,8 @@ HOST_ARCH='windows-x64'
 
 INFRA_ROOT="gs://$STORAGE_BUCKET/flutter_infra_release/flutter/$ENGINE_HASH"
 
-# TODO(eseidel): Terrible hack to make it work locally.
-GSUTIL="C:\Users\micro\AppData\Local\cloud-code\installer\google-cloud-sdk\bin\gsutil.cmd"
+# TODO(eseidel): Hack for eseidel's machine.
+export PATH="$PATH:/c/Users/micro/AppData/Local/cloud-code/installer/google-cloud-sdk/bin"
 
 # Android Arm64 release gen_snapshot
 # ARCH_OUT=$ENGINE_OUT/android_release_arm64
@@ -35,13 +35,13 @@ GSUTIL="C:\Users\micro\AppData\Local\cloud-code\installer\google-cloud-sdk\bin\g
 ARCH_OUT=$ENGINE_OUT/android_release
 ZIPS_OUT=$ARCH_OUT/zip_archives/android-arm-release
 ZIPS_DEST=$INFRA_ROOT/android-arm-release
-$GSUTIL cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+gsutil cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
 
 # Android x64 release gen_snapshot
 ARCH_OUT=$ENGINE_OUT/android_release_x64
 ZIPS_OUT=$ARCH_OUT/zip_archives/android-x64-release
 ZIPS_DEST=$INFRA_ROOT/android-x64-release
-$GSUTIL cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+gsutil cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
 
 # We could upload patch if we built it here.
 # gsutil cp $ENGINE_OUT/host_release/patch.zip $SHOREBIRD_ROOT/patch-win-x64.zip

--- a/build_engine/win_upload.sh
+++ b/build_engine/win_upload.sh
@@ -1,0 +1,47 @@
+#!/bin/sh -e
+
+# Usage:
+# ./upload.sh engine_path git_hash
+ENGINE_ROOT=$1
+ENGINE_HASH=$2
+
+STORAGE_BUCKET="download.shorebird.dev"
+SHOREBIRD_ROOT=gs://$STORAGE_BUCKET/shorebird/$ENGINE_HASH
+
+ENGINE_SRC=$ENGINE_ROOT/src
+ENGINE_OUT=$ENGINE_SRC/out
+ENGINE_FLUTTER=$ENGINE_SRC/flutter
+
+cd $ENGINE_FLUTTER
+
+# We do not generate a manifest file, we assume another builder did that.
+
+# TODO(eseidel): This should not be in shell, it's too complicated/repetative.
+
+HOST_ARCH='windows-x64'
+
+INFRA_ROOT="gs://$STORAGE_BUCKET/flutter_infra_release/flutter/$ENGINE_HASH"
+
+# TODO(eseidel): Terrible hack to make it work locally.
+GSUTIL="C:\Users\micro\AppData\Local\cloud-code\installer\google-cloud-sdk\bin\gsutil.cmd"
+
+# Android Arm64 release gen_snapshot
+# ARCH_OUT=$ENGINE_OUT/android_release_arm64
+# ZIPS_OUT=$ARCH_OUT/zip_archives/android-arm64-release
+# ZIPS_DEST=$INFRA_ROOT/android-arm64-release
+# gsutil cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+
+# Android Arm32 release gen_snapshot
+ARCH_OUT=$ENGINE_OUT/android_release
+ZIPS_OUT=$ARCH_OUT/zip_archives/android-arm-release
+ZIPS_DEST=$INFRA_ROOT/android-arm-release
+$GSUTIL cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+
+# Android x64 release gen_snapshot
+ARCH_OUT=$ENGINE_OUT/android_release_x64
+ZIPS_OUT=$ARCH_OUT/zip_archives/android-x64-release
+ZIPS_DEST=$INFRA_ROOT/android-x64-release
+$GSUTIL cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+
+# We could upload patch if we built it here.
+# gsutil cp $ENGINE_OUT/host_release/patch.zip $SHOREBIRD_ROOT/patch-win-x64.zip


### PR DESCRIPTION
We need to build and upload gen_snapshot for Windows hosts for Android.
This adds some basic build scripts which we will improve when we
actually set them up on a bot.