### PR TITLE
Reenable arm64 builds on windows

### DIFF
--- a/build_engine/win_build.sh
+++ b/build_engine/win_build.sh
@@ -16,12 +16,10 @@ cd $ENGINE_SRC
 # See https://github.com/flutter/engine/blob/e590b24f3962fda3ec9144dcee3f7565b195839a/ci/builders/windows_android_aot_engine.json
 
 
-# I haven't been able to get the right bits of VS2022 installed to build this.
+# If this gives you trouble, try using VS2019 instead.  I had trouble with 2022.
 # Android arm64 release
-# FileNotFoundError: [Errno 2] No such file or directory:
-# 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.36.32532\\arm64\\Microsoft.VC142.CRT\\msvcp140.dll'
-# ./flutter/tools/gn --android --android-cpu=arm64 --runtime-mode=release --no-goma
-# ninja -C ./out/android_release_arm64 gen_snapshot archive_win_gen_snapshot
+./flutter/tools/gn --android --android-cpu=arm64 --runtime-mode=release --no-goma
+ninja -C ./out/android_release_arm64 archive_win_gen_snapshot
 
 # Android arm32 release
 ./flutter/tools/gn --runtime-mode=release --android --no-goma

--- a/build_engine/win_upload.sh
+++ b/build_engine/win_upload.sh
@@ -26,10 +26,10 @@ INFRA_ROOT="gs://$STORAGE_BUCKET/flutter_infra_release/flutter/$ENGINE_HASH"
 export PATH="$PATH:/c/Users/micro/AppData/Local/cloud-code/installer/google-cloud-sdk/bin"
 
 # Android Arm64 release gen_snapshot
-# ARCH_OUT=$ENGINE_OUT/android_release_arm64
-# ZIPS_OUT=$ARCH_OUT/zip_archives/android-arm64-release
-# ZIPS_DEST=$INFRA_ROOT/android-arm64-release
-# gsutil cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
+ARCH_OUT=$ENGINE_OUT/android_release_arm64
+ZIPS_OUT=$ARCH_OUT/zip_archives/android-arm64-release
+ZIPS_DEST=$INFRA_ROOT/android-arm64-release
+gsutil cp $ZIPS_OUT/$HOST_ARCH.zip $ZIPS_DEST/$HOST_ARCH.zip
 
 # Android Arm32 release gen_snapshot
 ARCH_OUT=$ENGINE_OUT/android_release


### PR DESCRIPTION
These were disabled because they were broken for me locally with VS 2022.  They seem fixed
when I downgrade to VS 2019.